### PR TITLE
commented ext_autodoc in docs conf until it is released in pywps

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  emu:
+  {{ cookiecutter.project_slug }}:
     buildout: .
     image: birdhouse/{{ cookiecutter.project_slug }}
     environment:

--- a/{{cookiecutter.project_slug}}/docs/source/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/source/conf.py
@@ -35,7 +35,7 @@ import {{ cookiecutter.project_slug }}
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.viewcode',
               'sphinx.ext.napoleon',
-              'sphinx_autodoc_pywps',
+              #'pywps.ext_autodoc', # Available on master branch. Will be distributed with the 4.2 release.
               ]
 
 autoapi_type = 'python'

--- a/{{cookiecutter.project_slug}}/docs/source/configuration.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/configuration.rst
@@ -7,7 +7,7 @@ If you want to run on a different hostname or port then change the default value
 
 .. code-block:: sh
 
-   $ cd emu
+   $ cd {{ cookiecutter.project_slug }}
    $ vim custom.cfg
    $ cat custom.cfg
    [settings]


### PR DESCRIPTION
Also replaced references to emu by cookiecutter slug.
I think this closes issue #1 for now. Doc building works out of the box.