### PR TITLE
Fix #37: Enable pywps autodoc extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,8 @@ Then:
 
 For more details, see the `cookiecutter-pypackage tutorial`_.
 
+See the `babybird <http://babybird.rtfd.io/>`_ example of a generated bird.
+
 Development
 -----------
 

--- a/{{cookiecutter.project_slug}}/docs/source/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/source/conf.py
@@ -35,7 +35,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.viewcode',
               'sphinx.ext.napoleon',
               'sphinx.ext.todo',
-              #'pywps.ext_autodoc', # Available on master branch. Will be distributed with the 4.2 release.
+              'pywps.ext_autodoc',
               ]
 
 autoapi_type = 'python'

--- a/{{cookiecutter.project_slug}}/docs/source/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/index.rst
@@ -6,6 +6,7 @@
 
    installation
    configuration
+   processes
    changes
 
 Indices and tables

--- a/{{cookiecutter.project_slug}}/docs/source/processes.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/processes.rst
@@ -1,0 +1,29 @@
+.. _processes:
+
+Processes
+=========
+
+.. contents::
+    :local:
+    :depth: 1
+
+Sleep
+-----
+
+.. autoprocess:: {{ cookiecutter.project_slug }}.processes.wps_sleep.Sleep
+   :docstring:
+   :skiplines: 1
+
+Wordcounter
+-----------
+
+.. autoprocess:: {{ cookiecutter.project_slug }}.processes.wps_wordcounter.WordCounter
+   :docstring:
+   :skiplines: 1
+
+InOut
+-----
+
+.. autoprocess:: {{ cookiecutter.project_slug }}.processes.wps_inout.InOut
+   :docstring:
+   :skiplines: 1

--- a/{{cookiecutter.project_slug}}/requirements.txt
+++ b/{{cookiecutter.project_slug}}/requirements.txt
@@ -1,4 +1,4 @@
-pywps>=4.1.0
+pywps>=4.0.0
 jinja2
 click
 psutil

--- a/{{cookiecutter.project_slug}}/rtd.txt
+++ b/{{cookiecutter.project_slug}}/rtd.txt
@@ -1,0 +1,6 @@
+-e git+https://github.com/geopython/pywps.git#egg=pywps
+jinja2
+click
+psutil
+sphinx>=1.7
+sphinx-autoapi


### PR DESCRIPTION
## Overview

This PR fixes #37.

Changes:

* Enabled pywps autodoc extension in Sphinx `conf.py`.
* Added `rtd.txt` requirements for readthedocs.
* Added process documentation.


