### PR TITLE
Fix #39: set app_name in Makefile

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -1,6 +1,6 @@
 # Application
 APP_ROOT := $(CURDIR)
-APP_NAME := $(shell basename $(APP_ROOT))
+APP_NAME := {{ cookiecutter.project_slug }}
 
 # Anaconda
 ANACONDA_HOME ?= $(HOME)/anaconda


### PR DESCRIPTION
## Overview

This PR fixes #39.

Changes:

* Set APP_NAME in Makefile using cookiecutter.


