### PR TITLE
Fix #41: use project_repo_name for readthedocs links

### DIFF
--- a/{{cookiecutter.project_repo_name}}/.github/CONTRIBUTING.md
+++ b/{{cookiecutter.project_repo_name}}/.github/CONTRIBUTING.md
@@ -3,4 +3,4 @@
 Contributions are welcome, and they are greatly appreciated! Every little bit helps, and credit will always be given.
 
 Please read the Birdhouse [Contributer Guide](http://birdhouse.readthedocs.io/en/latest/contributing.html)
-and the [Cookiecutter Documentation](http://{{ cookiecutter.project_slug }}.readthedocs.io/en/latest/) to get started.
+and the [Cookiecutter Documentation](http://{{ cookiecutter.project_repo_name }}.readthedocs.io/en/latest/) to get started.

--- a/{{cookiecutter.project_repo_name}}/README.rst
+++ b/{{cookiecutter.project_repo_name}}/README.rst
@@ -2,7 +2,7 @@
 ===============================
 
 .. image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
-   :target: http://{{ cookiecutter.project_slug }}.readthedocs.io/en/latest/?badge=latest
+   :target: http://{{ cookiecutter.project_repo_name }}.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
 .. image:: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_repo_name }}.svg?branch=master
@@ -24,7 +24,7 @@
 {{ cookiecutter.project_short_description }}
 
 * Free software: {{ cookiecutter.open_source_license }}
-* Documentation: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io.
+* Documentation: https://{{ cookiecutter.project_repo_name | replace("_", "-") }}.readthedocs.io.
 
 Credits
 -------

--- a/{{cookiecutter.project_repo_name}}/{{cookiecutter.project_slug}}/default.cfg
+++ b/{{cookiecutter.project_repo_name}}/{{cookiecutter.project_slug}}/default.cfg
@@ -4,7 +4,7 @@ identification_abstract = {{ cookiecutter.project_short_description }}
 identification_keywords = =PyWPS, WPS, OGC, processing, birdhouse, {{ cookiecutter.project_slug }}, demo
 identification_keywords_type = theme
 provider_name = {{ cookiecutter.project_name }}
-provider_url=http://{{ cookiecutter.project_slug }}.readthedocs.org/en/latest/
+provider_url=http://{{ cookiecutter.project_repo_name }}.readthedocs.org/en/latest/
 
 [server]
 url = http://localhost:{{ cookiecutter.http_port }}/wps

--- a/{{cookiecutter.project_repo_name}}/{{cookiecutter.project_slug}}/processes/wps_inout.py
+++ b/{{cookiecutter.project_repo_name}}/{{cookiecutter.project_slug}}/processes/wps_inout.py
@@ -109,7 +109,7 @@ class InOut(Process):
             # profile=['birdhouse'],
             metadata=[
                 Metadata('Birdhouse', 'http://bird-house.github.io/'),
-                Metadata('User Guide', 'http://{{cookiecutter.project_slug}}.readthedocs.io/en/latest/',
+                Metadata('User Guide', 'http://{{cookiecutter.project_repo_name}}.readthedocs.io/en/latest/',
                          role='http://www.opengis.net/spec/wps/2.0/def/process/description/documentation')],
             inputs=inputs,
             outputs=outputs,

--- a/{{cookiecutter.project_repo_name}}/{{cookiecutter.project_slug}}/processes/wps_wordcounter.py
+++ b/{{cookiecutter.project_repo_name}}/{{cookiecutter.project_slug}}/processes/wps_wordcounter.py
@@ -34,7 +34,7 @@ class WordCounter(Process):
             abstract="Counts words in a given text.",
             version='1.0',
             metadata=[
-                Metadata('User Guide', 'http://{{cookiecutter.project_slug}}.readthedocs.io/en/latest/'),
+                Metadata('User Guide', 'http://{{cookiecutter.project_repo_name}}.readthedocs.io/en/latest/'),
                 Metadata('Free eBooks at Gutenberg', 'http://www.gutenberg.org/'),
                 Metadata('Example: Alice in Wonderland', 'http://www.gutenberg.org/cache/epub/19033/pg19033.txt'),
             ],


### PR DESCRIPTION
## Overview

This PR fixes #41.

Changes:

* Use cookiecutter variable `project_repo_name` also for readthedocs links.

## Related Issue / Discussion

See PR #43.
