### PR TITLE
use check_conda (#45)

### DIFF
--- a/{{cookiecutter.project_repo_name}}/Makefile
+++ b/{{cookiecutter.project_repo_name}}/Makefile
@@ -3,18 +3,9 @@ APP_ROOT := $(CURDIR)
 APP_NAME := {{ cookiecutter.project_slug }}
 
 # Anaconda
-ANACONDA_HOME ?= $(HOME)/anaconda
-CONDA_ENV ?= $(APP_NAME)
-
-# Choose Anaconda installer depending on your OS
-ANACONDA_URL = https://repo.continuum.io/miniconda
-ifeq "$(OS_NAME)" "Linux"
-FN := Miniconda3-latest-Linux-x86_64.sh
-else ifeq "$(OS_NAME)" "Darwin"
-FN := Miniconda3-latest-MacOSX-x86_64.sh
-else
-FN := unknown
-endif
+CONDA := $(shell command -v conda 2> /dev/null)
+ANACONDA_HOME := $(shell conda info --base 2> /dev/null)
+CONDA_ENV := $(APP_NAME)
 
 TEMP_FILES := *.egg-info *.log *.sqlite
 
@@ -43,28 +34,32 @@ help:
 
 ## Anaconda targets
 
-.PHONY: anaconda
-anaconda:
-	@echo "Installing Anaconda ..."
-	@test -d $(ANACONDA_HOME) || curl $(ANACONDA_URL)/$(FN) --silent --insecure --output "$(DOWNLOAD_CACHE)/$(FN)"
-	@test -d $(ANACONDA_HOME) || bash "$(DOWNLOAD_CACHE)/$(FN)" -b -p $(ANACONDA_HOME)
-	@echo "Please add '$(ANACONDA_HOME)/bin' to your PATH variable in '.bashrc'."
+.PHONY: check_conda
+check_conda:
+ifndef CONDA
+		$(error "Conda is not available. Please install miniconda: https://conda.io/miniconda.html")
+endif
 
 .PHONY: conda_env
-conda_env: anaconda
+conda_env: check_conda
 	@echo "Updating conda environment $(CONDA_ENV) ..."
-	"$(ANACONDA_HOME)/bin/conda" env update -n $(CONDA_ENV) -f environment.yml
+	"$(CONDA)" env update -n $(CONDA_ENV) -f environment.yml
+
+.PHONY: envclean
+envclean: check_conda
+	@echo "Removing conda env $(CONDA_ENV)"
+	@-"$(CONDA)" remove -n $(CONDA_ENV) --yes --all
 
 ## Build targets
 
 .PHONY: bootstrap
-bootstrap: conda_env bootstrap_dev
+bootstrap: check_conda conda_env bootstrap_dev
 	@echo "Bootstrap ..."
 
 .PHONY: bootstrap_dev
 bootstrap_dev:
 	@echo "Installing development requirements for tests and docs ..."
-	@-bash -c "$(ANACONDA_HOME)/bin/conda install -y -n $(CONDA_ENV) pytest flake8 sphinx bumpversion"
+	@-bash -c "$(CONDA) install -y -n $(CONDA_ENV) pytest flake8 sphinx bumpversion"
 	@-bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV) && pip install -r requirements_dev.txt"
 
 .PHONY: install
@@ -74,17 +69,17 @@ install: bootstrap
 	@echo "\nStart service with \`make start'"
 
 .PHONY: start
-start:
+start: check_conda
 	@echo "Starting application ..."
 	@-bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV) && $(APP_NAME) start -d"
 
 .PHONY: stop
-stop:
+stop: check_conda
 	@echo "Stopping application ..."
 	@-bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV) && $(APP_NAME) stop"
 
 .PHONY: status
-status:
+status: check_conda
 	@echo "Show status ..."
 	@-bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV) && $(APP_NAME) status"
 
@@ -94,11 +89,6 @@ clean: srcclean envclean
 	@-for i in $(TEMP_FILES); do \
   	test -e $$i && rm -v -rf $$i; \
   done
-
-.PHONY: envclean
-envclean:
-	@echo "Removing conda env $(CONDA_ENV)"
-	@-"$(ANACONDA_HOME)/bin/conda" remove -n $(CONDA_ENV) --yes --all
 
 .PHONY: srcclean
 srcclean:
@@ -114,24 +104,24 @@ distclean: clean
 ## Test targets
 
 .PHONY: test
-test:
+test: check_conda
 	@echo "Running tests (skip slow and online tests) ..."
 	@-bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV);pytest -v -m 'not slow and not online'"
 
 .PHONY: testall
-testall:
+testall: check_conda
 	@echo "Running all tests (including slow and online tests) ..."
 	@-bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV) && pytest -v"
 
 .PHONY: pep8
-pep8:
+pep8: check_conda
 	@echo "Running pep8 code style checks ..."
 	@-bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV) && flake8"
 
 ##  Sphinx targets
 
 .PHONY: docs
-docs:
+docs: check_conda
 	@echo "Generating docs with Sphinx ..."
 	@-bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV);$(MAKE) -C $@ clean html"
 	@echo "open your browser: firefox docs/build/html/index.html"


### PR DESCRIPTION
## Overview

This PR fixes #45.

Changes:

* Use `conda` command available in path.
* Check if conda is available or fail.
* Don't install conda by itself in default path `~/anaconda`.


