### PR TITLE
Raise makefile errors

### DIFF
--- a/{{cookiecutter.project_repo_name}}/Makefile
+++ b/{{cookiecutter.project_repo_name}}/Makefile
@@ -106,17 +106,17 @@ distclean: clean
 .PHONY: test
 test: check_conda
 	@echo "Running tests (skip slow and online tests) ..."
-	@-bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV);pytest -v -m 'not slow and not online'"
+	@bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV);pytest -v -m 'not slow and not online'"
 
 .PHONY: testall
 testall: check_conda
 	@echo "Running all tests (including slow and online tests) ..."
-	@-bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV) && pytest -v"
+	@bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV) && pytest -v"
 
 .PHONY: pep8
 pep8: check_conda
 	@echo "Running pep8 code style checks ..."
-	@-bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV) && flake8"
+	@bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV) && flake8"
 
 ##  Sphinx targets
 


### PR DESCRIPTION
## Overview

While it might be preferable to ignore errors during portions of the buildout phase, it would be good to loudly raise errors during the testing phase.

## Changes

Removed the hyphens (`-`) before `make test`, `make testall`, and `make pep8`. 

## Additional Information

Links to other issues or sources.
