### PR TITLE
added setuptools to conda env

### DIFF
--- a/{{cookiecutter.project_repo_name}}/.travis.yml
+++ b/{{cookiecutter.project_repo_name}}/.travis.yml
@@ -17,6 +17,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
+  - conda install setuptools
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a


### PR DESCRIPTION
## Overview

This PR fixes a conda issue on travis. `conda update conda` failed because `setuptools` was not installed.

Changes:

* Added `conda install setuptools` to travis config.

## Related Issue / Discussion

https://github.com/bird-house/hummingbird/pull/34

## Additional Information


