### PR TITLE
updated links to dev guide

### DIFF
--- a/{{cookiecutter.project_repo_name}}/.github/CONTRIBUTING.md
+++ b/{{cookiecutter.project_repo_name}}/.github/CONTRIBUTING.md
@@ -2,5 +2,5 @@
 
 Contributions are welcome, and they are greatly appreciated! Every little bit helps, and credit will always be given.
 
-Please read the Birdhouse [Contributer Guide](http://birdhouse.readthedocs.io/en/latest/contributing.html)
-and the [Cookiecutter Documentation](http://{{ cookiecutter.project_repo_name }}.readthedocs.io/en/latest/) to get started.
+Please read the Birdhouse [Developer Guide](https://birdhouse.readthedocs.io/en/latest/dev_guide.html)
+and the [{{ cookiecutter.project_name }} Documentation](http://{{ cookiecutter.project_repo_name }}.readthedocs.io/en/latest/) to get started.

--- a/{{cookiecutter.project_repo_name}}/README.rst
+++ b/{{cookiecutter.project_repo_name}}/README.rst
@@ -23,8 +23,23 @@
 
 {{ cookiecutter.project_short_description }}
 
-* Free software: {{ cookiecutter.open_source_license }}
-* Documentation: https://{{ cookiecutter.project_repo_name | replace("_", "-") }}.readthedocs.io.
+Documentation
+-------------
+
+Learn more about {{ cookiecutter.project_name }} in its official documentation at
+https://{{ cookiecutter.project_repo_name | replace("_", "-") }}.readthedocs.io.
+
+Contributing
+------------
+
+You can find information about contributing in our `Developer Guide`_.
+
+Please use bumpversion_ to release a new version.
+
+License
+-------
+
+Free software: {{ cookiecutter.open_source_license }}
 
 Credits
 -------
@@ -33,3 +48,5 @@ This package was created with Cookiecutter_ and the `bird-house/cookiecutter-bir
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`bird-house/cookiecutter-birdhouse`: https://github.com/bird-house/cookiecutter-birdhouse
+.. _`Developer Guide`: https://{{ cookiecutter.project_repo_name | replace("_", "-") }}.readthedocs.io/en/latest/dev_guide.html
+.. _bumpversion: https://{{ cookiecutter.project_repo_name | replace("_", "-") }}.readthedocs.io/en/latest/dev_guide.html#bump-a-new-version


### PR DESCRIPTION
## Overview

This PR adds links to the dev-guide in the Readme to make the release with bumpversion more visible.

It fixes also the links in `CONTRIBUTING.md`

## Related Issue / Discussion

See discussion in FlyingPigeon PR:
https://github.com/bird-house/flyingpigeon/pull/300

## Additional Information

Taken xarray readme as example:
https://github.com/pydata/xarray/blob/master/README.rst

