### PR TITLE
fix conda env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,9 +5,8 @@ dependencies:
 - pip
 - cryptography
 - pyyaml
+- cookiecutter
 - pytest
-- pip:
-  - cookiecutter
-  - bumpversion
-  - watchdog
-  - pytest-cookies
+- pytest-cookies
+- bumpversion
+- watchdog

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: cookiecutter-birdhouse
 channels:
 - defaults
+- conda-forge
 dependencies:
 - pip
 - cryptography


### PR DESCRIPTION
## Overview

This PR updates the conda env to handle the latest cookiecutter release (1.7.0). It uses only conda packages to automatically resolve dependencies. Before `pip` installation for `pytest-cookies` failed due to cookiecutter dependency.


## Related Issue / Discussion

## Additional Information


