### PR TITLE
Issue 77 fix readme links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Cookiecutter for Birdhouse
 Cookiecutter_ is a command-line utility to create projects from templates. This `cookiecutter-birdhouse`
 template creates a barebone PyWPS server adhering to Birdhouse conventions. It comes complete with a
 framework for installation, configuration, deployment, documentation and tests. It even includes a
-*Dockerfile* for containerization! Create your project then get started writing new WPS
+`Dockerfile` for containerization! Create your project then get started writing new WPS
 processes in minutes.
 
 * GitHub repo: https://github.com/bird-house/cookiecutter-birdhouse/
@@ -40,17 +40,11 @@ Features
 --------
 
 * Ready-made PyWPS server (a bird)
-* Pre-configured `travis.yml`_ for Travis-CI_ automated deployment and testing
-* Pre-configured `codacy.yml`_ for automated Codacy_ code review
-* A Dockerfile_ and `docker-compose.yml`_ for containerization
+* Pre-configured ``travis.yml`` for Travis-CI_ automated deployment and testing
+* Pre-configured ``codacy.yml`` for automated Codacy_ code review
+* A ``Dockerfile`` and ``docker-compose.yml`` for containerization
 * Preconfigured Sphinx_ documentation that can be hosted on ReadTheDocs_
-* A Makefile_ to install the code, start, stop and poll the server and more
-
-.. _travis.yml: ./{{cookiecutter.project_repo_name}}/.travis.yml
-.. _codacy.yml: ./{{cookiecutter.project_repo_name}}/.codacy.yml
-.. _Dockerfile: ./{{cookiecutter.project_repo_name}}/Dockerfile
-.. _docker-compose.yml: ./{{cookiecutter.project_repo_name}}/docker-compose.yml
-.. _Makefile: ./{{cookiecutter.project_repo_name}}/Makefile
+* A ``Makefile`` to install the code, start, stop and poll the server and more
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -20,10 +20,10 @@ Cookiecutter for Birdhouse
 
 *A Cookiecutter template for a Birdhouse bird package*
 
-Cookiecutter_ is a command-line utility to create projects from templates. This `cookiecutter-birdhouse`
+Cookiecutter_ is a command-line utility to create projects from templates. This *cookiecutter-birdhouse*
 template creates a barebone PyWPS server adhering to Birdhouse conventions. It comes complete with a
 framework for installation, configuration, deployment, documentation and tests. It even includes a
-`Dockerfile` for containerization! Create your project then get started writing new WPS
+*Dockerfile* for containerization! Create your project then get started writing new WPS
 processes in minutes.
 
 * GitHub repo: https://github.com/bird-house/cookiecutter-birdhouse/

--- a/README.rst
+++ b/README.rst
@@ -40,11 +40,13 @@ Features
 --------
 
 * Ready-made PyWPS server (a bird)
-* Pre-configured ``travis.yml`` for Travis-CI_ automated deployment and testing
+* Pre-configured travis.yml_ for Travis-CI_ automated deployment and testing
 * Pre-configured ``codacy.yml`` for automated Codacy_ code review
 * A ``Dockerfile`` and ``docker-compose.yml`` for containerization
 * Preconfigured Sphinx_ documentation that can be hosted on ReadTheDocs_
 * A ``Makefile`` to install the code, start, stop and poll the server and more
+
+.. _travis.yml: ./{{cookiecutter.project_repo_name}}/.travis.yml
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -40,11 +40,17 @@ Features
 --------
 
 * Ready-made PyWPS server (a bird)
-* Pre-configured :file:`.travis.yml` for Travis-CI_ automated deployment and testing
-* Pre-configured :file:`.codacy.yml` for automated Codacy_ code review
-* A :file:`Dockerfile` and :file:`docker-compose.yml` for containerization
+* Pre-configured `travis.yml`_ for Travis-CI_ automated deployment and testing
+* Pre-configured `codacy.yml`_ for automated Codacy_ code review
+* A Dockerfile_ and `docker-compose.yml`_ for containerization
 * Preconfigured Sphinx_ documentation that can be hosted on ReadTheDocs_
-* A :file:`Makefile` to install the code, start, stop and poll the server and more
+* A Makefile_ to install the code, start, stop and poll the server and more
+
+.. _travis.yml: ./.travis.yml
+.. _codacy.yml: ./.codacy.yml
+.. _Dockerfile: ./Dockerfile
+.. _docker-compose.yml: ./docker-compose.yml
+.. _Makefile: ./Makefile
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Cookiecutter for Birdhouse
 Cookiecutter_ is a command-line utility to create projects from templates. This `cookiecutter-birdhouse`
 template creates a barebone PyWPS server adhering to Birdhouse conventions. It comes complete with a
 framework for installation, configuration, deployment, documentation and tests. It even includes a
-:file:`Dockerfile` for containerization! Create your project then get started writing new WPS
+*Dockerfile* for containerization! Create your project then get started writing new WPS
 processes in minutes.
 
 * GitHub repo: https://github.com/bird-house/cookiecutter-birdhouse/
@@ -46,11 +46,11 @@ Features
 * Preconfigured Sphinx_ documentation that can be hosted on ReadTheDocs_
 * A Makefile_ to install the code, start, stop and poll the server and more
 
-.. _travis.yml: ./.travis.yml
-.. _codacy.yml: ./.codacy.yml
-.. _Dockerfile: ./Dockerfile
-.. _docker-compose.yml: ./docker-compose.yml
-.. _Makefile: ./Makefile
+.. _travis.yml: ./{{cookiecutter.project_repo_name}}/.travis.yml
+.. _codacy.yml: ./{{cookiecutter.project_repo_name}}/.codacy.yml
+.. _Dockerfile: ./{{cookiecutter.project_repo_name}}/Dockerfile
+.. _docker-compose.yml: ./{{cookiecutter.project_repo_name}}/docker-compose.yml
+.. _Makefile: ./{{cookiecutter.project_repo_name}}/Makefile
 
 Installation
 ------------


### PR DESCRIPTION
## Overview

This PR fixes #77. It skips the `file:` directive in the readme. Referenced files are part of the template and not the docs.

## Related Issue / Discussion

## Additional Information


