### PR TITLE
Add note for conda forge in .travis.yml

### DIFF
--- a/{{cookiecutter.project_repo_name}}/.travis.yml
+++ b/{{cookiecutter.project_repo_name}}/.travis.yml
@@ -23,6 +23,8 @@ install:
   - conda info -a
   # Prepare env with Python version
   - conda create -n {{ cookiecutter.project_slug }} python=$TRAVIS_PYTHON_VERSION
+  # Note: if using conda-forge, specify the channel with this command instead
+  # - conda create -n {{ cookiecutter.project_slug }} -c conda-forge python=$TRAVIS_PYTHON_VERSION
   # Update now the env with our environment
   - conda env update -f environment.yml
   - source activate {{ cookiecutter.project_slug }}


### PR DESCRIPTION
## Overview

I just wanted to add a note in `.travis.yml` for a bug that bit us in finch that was a bit hard to find. https://github.com/bird-house/finch/pull/63

When our packages come from conda-forge, some packages (notably GDAL) will get installed with the channel where python itself came from. So if python was installed from defaults, installing GDAL with `conda install -c conda-forge GDAL` will still install it from defaults.
