### PR TITLE
Backport fixes from Raven PR

### DIFF
--- a/{{cookiecutter.project_repo_name}}/Makefile
+++ b/{{cookiecutter.project_repo_name}}/Makefile
@@ -140,8 +140,9 @@ refresh-notebooks:
 docs:
 	@echo "Generating docs with Sphinx ..."
 	@-bash -c '$(MAKE) -C $@ clean html'
-	@echo "Opening browser to: file:/$(APP_ROOT)/docs/build/html/index.html"
-	@-bash -c 'xdg-open $(APP_ROOT)/docs/build/html/index.html'
+	@echo "Open your browser to: file:/$(APP_ROOT)/docs/build/html/index.html"
+	## do not execute xdg-open automatically since it hangs travis and job does not complete
+	@echo "xdg-open $(APP_ROOT)/docs/build/html/index.html"
 
 ## Deployment targets
 

--- a/{{cookiecutter.project_repo_name}}/docs/source/conf.py
+++ b/{{cookiecutter.project_repo_name}}/docs/source/conf.py
@@ -47,6 +47,9 @@ extensions = [
     "IPython.sphinxext.ipython_console_highlighting",
 ]
 
+# We are using mock imports in readthedocs, so probably safer to not run the notebooks
+nbsphinx_execute = 'never'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
project repo Makefile: do not execute xdg-open since it hangs in TravisCI build

project repo docs conf: do not execute notebooks because we use mock imports

Those are backports from Raven PR https://github.com/Ouranosinc/raven/pull/272
