### PR TITLE
Doc how to use cruft and template improvement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,9 @@ framework for installation, configuration, deployment, documentation and tests. 
 :file:`Dockerfile` for containerization! Create your project then get started writing new WPS
 processes in minutes.
 
+To keep projects up-to-date with the cookiecutter template, Cruft_ will be
+used.
+
 * GitHub repo: https://github.com/bird-house/cookiecutter-birdhouse/
 * Documentation: http://cookiecutter-birdhouse.readthedocs.io/en/latest/
 * Free software: BSD license
@@ -49,42 +52,44 @@ Features
 Installation
 ------------
 
-Prior to installing cookiecutter-birdhouse, the cookiecutter package must be installed in your environment.
-This is achieved via the following command:
+Prior to installing cookiecutter-birdhouse, the cookiecutter and cruft package must be installed in your environment.
+This is achieved via the following commands:
 
 .. code-block:: console
 
     $ conda install -c conda-forge cookiecutter
+    $ pip install cruft
 
-With cookiecutter installed, the cookiecutter-birdhouse template can be installed with:
+With cookiecutter and cruft installed, the cookiecutter-birdhouse template can be installed with:
 
 .. code-block:: console
 
-    $ cookiecutter https://github.com/bird-house/cookiecutter-birdhouse.git
+    $ cruft create https://github.com/bird-house/cookiecutter-birdhouse.git
 
 Once cookiecutter clones the template, you will be asked a series of questions related to your project:
 
 .. code-block:: console
 
-    $ full_name [Full Name]: Enter your full name.
+    full_name [Full Name]: 
+    email [your@email]: 
+    github_username [bird-house]: 
+    project_name [Babybird]: 
+    project_slug [babybird]: 
+    project_repo_name [babybird]: 
+    project_readthedocs_name [babybird]: 
+    project_short_description [A Web Processing Service for Climate Data Analysis.]: 
+    version [0.1.0]: 
+    Select open_source_license:
+    1 - Apache Software License 2.0
+    2 - MIT license
+    3 - BSD license
+    4 - ISC license
+    5 - GNU General Public License v3
+    Choose from 1, 2, 3, 4, 5 [1]: 
+    http_port [5000]: 
 
-    $ email [Email Address]: Enter your email address.
-
-    $ github_username [bird-house]: Accept the default or enter your github username.
-
-    $ project_name [Babybird]: The name of your new bird.
-
-    $ project_slug [babybird]: The name of your bird used as Python package.
-
-    $ project_short_description [Short description]: Enter a short description about your project.
-
-    $ version [0.1.0]: Enter the version number for your application.
-
-    $ http_port [5000]: The HTTP port on which your service will be accessible.
-
-    $ https_port [25000]: The HTTPS port on which your service will be accessible.
-
-    $ output_port [8090]: The HTTP port on which your service outputs will be accessible.
+The answer to all those questions are recorded in the ``.cruft.json`` file in
+your generated bird.
 
 Usage
 -----
@@ -102,6 +107,22 @@ Then:
 For more details, see the `cookiecutter-pypackage tutorial`_.
 
 See the `babybird <http://babybird.rtfd.io/>`_ example of a generated bird.
+
+To keep the generated bird up-to-date with the cookiecutter template:
+
+.. code-block:: console
+
+    $ cruft update  # uses configurations in the .cruft.json file
+
+Cruft can be configured to ignore template change to certain files, see
+https://timothycrosley.github.io/cruft/#updating-a-project.  Potential files to
+ignore:
+
+* initial example files because we do not want to keep those
+* environment files and list of processes, list of tutorial notebooks since they
+  natually are different between each bird
+
+See cruft_skip_ example.
 
 Development
 -----------
@@ -154,7 +175,9 @@ See the bumpversion_ documentation for details.
 
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
+.. _Cruft: https://timothycrosley.github.io/cruft/
 .. _`cookiecutter-pypackage tutorial`: https://cookiecutter-pypackage.readthedocs.io/en/latest/tutorial.html
+.. _cruft_skip: https://github.com/Ouranosinc/raven/blob/4d32f82cc993e5569eb7afc86aefd7ed88824b78/.cruft.json#L4-L14
 .. _Travis-CI: http://travis-ci.org/
 .. _Codacy: http://codacy.com
 .. _Sphinx: http://sphinx-doc.org/

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,7 @@ framework for installation, configuration, deployment, documentation and tests. 
 :file:`Dockerfile` for containerization! Create your project then get started writing new WPS
 processes in minutes.
 
-To keep projects up-to-date with the cookiecutter template, Cruft_ will be
-used.
+You may at any time update your project using the latest cookiecutter template using Cruft_.
 
 * GitHub repo: https://github.com/bird-house/cookiecutter-birdhouse/
 * Documentation: http://cookiecutter-birdhouse.readthedocs.io/en/latest/
@@ -52,7 +51,7 @@ Features
 Installation
 ------------
 
-Prior to installing cookiecutter-birdhouse, the cookiecutter and cruft package must be installed in your environment.
+Prior to installing cookiecutter-birdhouse, the cookiecutter and cruft packages must be installed in your environment.
 This is achieved via the following commands:
 
 .. code-block:: console
@@ -114,13 +113,13 @@ To keep the generated bird up-to-date with the cookiecutter template:
 
     $ cruft update  # uses configurations in the .cruft.json file
 
-Cruft can be configured to ignore template change to certain files, see
+Cruft can be configured to ignore template changes to certain files, see
 https://timothycrosley.github.io/cruft/#updating-a-project.  Potential files to
 ignore:
 
-* initial example files because we do not want to keep those
+* demonstration files, because they are meant to be erased
 * environment files and list of processes, list of tutorial notebooks since they
-  natually are different between each bird
+  naturally are different between each bird
 
 See cruft_skip_ example.
 
@@ -135,7 +134,7 @@ This will create the ``.cruft.json`` file so subsequently ``cruft update`` can
 be used.  You will need to answer the same questions as ``cruft create``
 above.
 
-Note after ``cruft link`` the ``commit`` field in the ``.cruft.json`` file will
+Note that after ``cruft link``, the ``commit`` field in the ``.cruft.json`` file will
 initially be wrong.  To ensure a proper subsequent ``cruft update``, you need
 to edit the ``.cruft.json`` file and put the proper last commit of the
 cookiecutter used in that ``commit`` field.

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,22 @@ ignore:
 
 See cruft_skip_ example.
 
+To link already generated project that was not initially generated using
+``cruft create``:
+
+.. code-block:: console
+
+    $ cruft link https://github.com/bird-house/cookiecutter-birdhouse
+
+This will create the ``.cruft.json`` file so subsequently ``cruft update`` can
+be used.  You will need to answer the same questions as ``cruft create``
+above.
+
+Note after ``cruft link`` the ``commit`` field in the ``.cruft.json`` file will
+initially be wrong.  To ensure a proper subsequent ``cruft update``, you need
+to edit the ``.cruft.json`` file and put the proper last commit of the
+cookiecutter used in that ``commit`` field.
+
 Development
 -----------
 

--- a/{{cookiecutter.project_repo_name}}/.travis.yml
+++ b/{{cookiecutter.project_repo_name}}/.travis.yml
@@ -46,4 +46,5 @@ before_script:
   - sleep 2
 script:
   - pytest
+  - make test-notebooks
   - flake8

--- a/{{cookiecutter.project_repo_name}}/environment-docs.yml
+++ b/{{cookiecutter.project_repo_name}}/environment-docs.yml
@@ -1,6 +1,6 @@
 name: {{ cookiecutter.project_slug }}
 channels:
-#- conda-forge
+- conda-forge
 - defaults
 dependencies:
 - pywps>=4.2

--- a/{{cookiecutter.project_repo_name}}/requirements_dev.txt
+++ b/{{cookiecutter.project_repo_name}}/requirements_dev.txt
@@ -10,3 +10,4 @@ sphinx>=1.7
 bump2version
 twine
 cruft
+# add extra not in cookiecutter below to prevent merge conflict when refreshing cookiecutter

--- a/{{cookiecutter.project_repo_name}}/requirements_dev.txt
+++ b/{{cookiecutter.project_repo_name}}/requirements_dev.txt
@@ -9,3 +9,4 @@ nbconvert
 sphinx>=1.7
 bump2version
 twine
+cruft

--- a/{{cookiecutter.project_repo_name}}/requirements_dev.txt
+++ b/{{cookiecutter.project_repo_name}}/requirements_dev.txt
@@ -10,4 +10,4 @@ sphinx>=1.7
 bump2version
 twine
 cruft
-# add extra not in cookiecutter below to prevent merge conflict when refreshing cookiecutter
+# Changing dependencies above this comment will create merge conflicts when updating the cookiecutter template with cruft. Add extra requirements below this line. 

--- a/{{cookiecutter.project_repo_name}}/setup.cfg
+++ b/{{cookiecutter.project_repo_name}}/setup.cfg
@@ -18,6 +18,10 @@ replace = release = '{new_version}'
 search = Version="{current_version}"
 replace = Version="{new_version}"
 
+[bumpversion:file:.cruft.json]
+search = "version": "{current_version}",
+replace = "version": "{new_version}",
+
 [tool:pytest]
 addopts =
 	--strict


### PR DESCRIPTION
This PR fixes https://github.com/bird-house/cookiecutter-birdhouse/issues/61.

This PR is a continuation of PR https://github.com/bird-house/cookiecutter-birdhouse/pull/85.

Raven PR https://github.com/Ouranosinc/raven/pull/276 matching this PR.

Changes:

* Added documentation to use cruft initially to generate the project and after the fact to keep project in sync with cookiecutter template update.

* Fix missing bump version config for new `.cruft.json` file.

* Prevent merge conflicts on future cookiecutter template refresh in `requirements_dev.txt`.

* Add `make test-notebooks` to TravisCI.

