### PR TITLE
fix conda env and docker build

### DIFF
--- a/{{cookiecutter.project_repo_name}}/Dockerfile
+++ b/{{cookiecutter.project_repo_name}}/Dockerfile
@@ -17,10 +17,10 @@ COPY . /opt/wps
 WORKDIR /opt/wps
 
 # Create conda environment
-RUN conda env create -n wps -f environment.yml
+RUN conda create -n wps -c conda-forge python=3.7 pywps=4.2
 
 # Install WPS
-RUN ["/bin/bash", "-c", "source activate wps && python setup.py develop"]
+RUN ["/bin/bash", "-c", "source activate wps && python setup.py install"]
 
 # Start WPS service on port {{ cookiecutter.http_port }} on 0.0.0.0
 EXPOSE {{ cookiecutter.http_port }}

--- a/{{cookiecutter.project_repo_name}}/Dockerfile
+++ b/{{cookiecutter.project_repo_name}}/Dockerfile
@@ -16,7 +16,7 @@ COPY . /opt/wps
 
 WORKDIR /opt/wps
 
-# Create conda environment
+# Create conda environment with PyWPS
 RUN conda create -n wps -c conda-forge python=3.7 pywps=4.2
 
 # Install WPS

--- a/{{cookiecutter.project_repo_name}}/environment.yml
+++ b/{{cookiecutter.project_repo_name}}/environment.yml
@@ -1,10 +1,11 @@
 name: {{ cookiecutter.project_slug }}
 channels:
-#- conda-forge
+- conda-forge
 - defaults
 dependencies:
 - pip
-- pywps>=4.2
+- python>=3.6,<3.8
+- pywps=4.2
 - jinja2
 - click
 - psutil

--- a/{{cookiecutter.project_repo_name}}/environment.yml
+++ b/{{cookiecutter.project_repo_name}}/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - pip
 - python>=3.6,<3.8
-- pywps=4.2
+- pywps>=4.2.4,<4.3
 - jinja2
 - click
 - psutil


### PR DESCRIPTION
## Overview

This PR fixes #91.

Changes:

* Enabled conda-forge channel in conda `environment.yml`.
* Restricted python version ... pywps async mode does not work on python 3.8.
* Docker conda env installs pywps only.

## Related Issue / Discussion

#91

## Additional Information

PyWPS issue with multiprocessing on Python 3.8:
https://github.com/geopython/pywps/issues/508
