### PR TITLE
fix empty autodoc processes list silent docs build failure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -193,7 +193,7 @@ See the bumpversion_ documentation for details.
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _Cruft: https://timothycrosley.github.io/cruft/
 .. _`cookiecutter-pypackage tutorial`: https://cookiecutter-pypackage.readthedocs.io/en/latest/tutorial.html
-.. _cruft_skip: https://github.com/Ouranosinc/raven/blob/4d32f82cc993e5569eb7afc86aefd7ed88824b78/.cruft.json#L4-L14
+.. _cruft_skip: https://github.com/bird-house/emu/commit/fb1ff9ffdf9e7f0282b36ff0727996cba3bf081a
 .. _cruft_link: https://github.com/bird-house/finch/pull/128/commits/0b0d7f37966cbb5bf345dfd4b4ac7953f38f4867
 .. _Travis-CI: http://travis-ci.org/
 .. _Codacy: http://codacy.com

--- a/{{cookiecutter.project_repo_name}}/.readthedocs.yml
+++ b/{{cookiecutter.project_repo_name}}/.readthedocs.yml
@@ -8,6 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
+  fail_on_warning: true
 
 # Build documentation with MkDocs
 #mkdocs:

--- a/{{cookiecutter.project_repo_name}}/.readthedocs.yml
+++ b/{{cookiecutter.project_repo_name}}/.readthedocs.yml
@@ -8,6 +8,8 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
+  # fail_on_warning might generate hard to fix error, in this case it can be
+  # disabled but this also means those errors will fail silently, choose wisely.
   fail_on_warning: true
 
 # Build documentation with MkDocs

--- a/{{cookiecutter.project_repo_name}}/.travis.yml
+++ b/{{cookiecutter.project_repo_name}}/.travis.yml
@@ -46,4 +46,6 @@ script:
   - pytest
   - make test-notebooks
   - flake8
-  - make docs
+  - make docs  # default html
+  - make SPHINXOPTS='-b epub' docs  # to match RtD
+  - make SPHINXOPTS='-b latex' docs  # to match RtD

--- a/{{cookiecutter.project_repo_name}}/.travis.yml
+++ b/{{cookiecutter.project_repo_name}}/.travis.yml
@@ -5,6 +5,7 @@ os:
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 branches:
   only:
     - master

--- a/{{cookiecutter.project_repo_name}}/Makefile
+++ b/{{cookiecutter.project_repo_name}}/Makefile
@@ -143,7 +143,7 @@ refresh-notebooks:
 .PHONY: docs
 docs:
 	@echo "Generating docs with Sphinx ..."
-	@-bash -c '$(MAKE) -C $@ clean html'
+	@bash -c '$(MAKE) -C $@ clean html'
 	@echo "Open your browser to: file:/$(APP_ROOT)/docs/build/html/index.html"
 	## do not execute xdg-open automatically since it hangs travis and job does not complete
 	@echo "xdg-open $(APP_ROOT)/docs/build/html/index.html"

--- a/{{cookiecutter.project_repo_name}}/docs/Makefile
+++ b/{{cookiecutter.project_repo_name}}/docs/Makefile
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" -W $(SPHINXOPTS) $(O)

--- a/{{cookiecutter.project_repo_name}}/docs/source/conf.py
+++ b/{{cookiecutter.project_repo_name}}/docs/source/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "sphinx.ext.todo",
     "pywps.ext_autodoc",
     "sphinx.ext.autosectionlabel",
+    "sphinx.ext.imgconverter",
     "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
 ]

--- a/{{cookiecutter.project_repo_name}}/docs/source/conf.py
+++ b/{{cookiecutter.project_repo_name}}/docs/source/conf.py
@@ -109,6 +109,9 @@ todo_include_todos = False
 # Suppress "WARNING: unknown mimetype for ..." when building EPUB.
 suppress_warnings = ['epub.unknown_project_files']
 
+# Avoid "configuration.rst:4:duplicate label configuration, other instance in configuration.rst"
+autosectionlabel_prefix_document = True
+
 
 # -- Options for HTML output -------------------------------------------
 

--- a/{{cookiecutter.project_repo_name}}/docs/source/conf.py
+++ b/{{cookiecutter.project_repo_name}}/docs/source/conf.py
@@ -84,7 +84,7 @@ author = "{{ cookiecutter.full_name }}"
 # the built documents.
 #
 # The short X.Y version.
-version = ""
+version = "{{ cookiecutter.version }}"
 # The full version, including alpha/beta/rc tags.
 release = "{{ cookiecutter.version }}"
 

--- a/{{cookiecutter.project_repo_name}}/docs/source/conf.py
+++ b/{{cookiecutter.project_repo_name}}/docs/source/conf.py
@@ -53,7 +53,11 @@ autodoc_mock_imports = ["numpy", "xarray", "fiona", "rasterio", "shapely",
                         "affine", "rasterstats", "spotpy", "matplotlib",
                         "scipy", "unidecode", "gdal", "sentry_sdk", "dask",
                         "numba", "parse", "siphon", "sklearn", "cftime",
-                        "netCDF4"]
+                        "netCDF4", "bottleneck"]
+
+# Monkeypatch constant because the following are mock imports.
+import numpy
+numpy.pi = 3.1416
 
 # We are using mock imports in readthedocs, so probably safer to not run the notebooks
 nbsphinx_execute = 'never'

--- a/{{cookiecutter.project_repo_name}}/docs/source/conf.py
+++ b/{{cookiecutter.project_repo_name}}/docs/source/conf.py
@@ -61,8 +61,9 @@ autodoc_mock_imports = ["numpy", "xarray", "fiona", "rasterio", "shapely",
                         "scikit-learn", "cairo"]
 
 # Monkeypatch constant because the following are mock imports.
-import numpy
-numpy.pi = 3.1416
+# Only works if numpy is actually installed and at the same time being mocked.
+#import numpy
+#numpy.pi = 3.1416
 
 # We are using mock imports in readthedocs, so probably safer to not run the notebooks
 nbsphinx_execute = 'never'

--- a/{{cookiecutter.project_repo_name}}/docs/source/conf.py
+++ b/{{cookiecutter.project_repo_name}}/docs/source/conf.py
@@ -49,12 +49,16 @@ extensions = [
 ]
 
 # To avoid having to install these and burst memory limit on ReadTheDocs.
+# List of all tested working mock imports from all birds so new birds can
+# inherit without having to test which work which do not.
 autodoc_mock_imports = ["numpy", "xarray", "fiona", "rasterio", "shapely",
                         "osgeo", "geopandas", "pandas", "statsmodels",
                         "affine", "rasterstats", "spotpy", "matplotlib",
                         "scipy", "unidecode", "gdal", "sentry_sdk", "dask",
                         "numba", "parse", "siphon", "sklearn", "cftime",
-                        "netCDF4", "bottleneck"]
+                        "netCDF4", "bottleneck", "ocgis", "geotiff", "geos",
+                        "hdf4", "hdf5", "zlib", "pyproj", "proj", "cartopy",
+                        "scikit-learn", "cairo"]
 
 # Monkeypatch constant because the following are mock imports.
 import numpy

--- a/{{cookiecutter.project_repo_name}}/docs/source/conf.py
+++ b/{{cookiecutter.project_repo_name}}/docs/source/conf.py
@@ -106,6 +106,9 @@ pygments_style = "sphinx"
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# Suppress "WARNING: unknown mimetype for ..." when building EPUB.
+suppress_warnings = ['epub.unknown_project_files']
+
 
 # -- Options for HTML output -------------------------------------------
 

--- a/{{cookiecutter.project_repo_name}}/requirements_dev.txt
+++ b/{{cookiecutter.project_repo_name}}/requirements_dev.txt
@@ -1,4 +1,5 @@
-pytest
+# https://github.com/computationalmodelling/nbval/issues/139 broken by pytest 6.0.0
+pytest==5.4.3
 flake8
 pytest-flake8
 ipython

--- a/{{cookiecutter.project_repo_name}}/setup.cfg
+++ b/{{cookiecutter.project_repo_name}}/setup.cfg
@@ -11,8 +11,8 @@ search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
 [bumpversion:file:docs/source/conf.py]
-search = release = '{current_version}'
-replace = release = '{new_version}'
+search = version|release = {current_version}
+replace = {new_version}
 
 [bumpversion:file:Dockerfile]
 search = Version="{current_version}"


### PR DESCRIPTION
Currently, autodoc failure are treated as warnings only, resulting in
empty processes list, see
https://pavics-sdi.readthedocs.io/projects/raven/en/latest/processes.html.

This fix will turn these warnings into build failure on RtD and on
Travis-CI so we can catch those errors earlier.

Right now these warnings are falling silently !

Also changed Travis-CI config so it also builds Epub and Latex format as RtD to catch RtD errors before PR is merged.

Common fixes for those warnings are backported here.

Bonus we also catch nonexisting document reference and missing reference
in toctree, see below sample Raven warnings during docs build.

Raven succesful build logs with warnings on RtD:
https://readthedocs.org/api/v2/build/11487109.txt

/home/docs/checkouts/readthedocs.org/user_builds/pavics-raven/checkouts/latest/docs/source/index.rst:14:
WARNING: toctree contains reference to nonexisting document 'pyraven'
WARNING: autodoc: failed to import process 'processes.RavenProcess' from
module 'raven'; the following exception was raised:
No module named 'xclim.core'
WARNING: autodoc: failed to import process
'processes.RavenGR4JCemaNeigeProcess' from module 'raven'; the following
exception was raised:
No module named 'xclim.core'
WARNING: autodoc: failed to import process
'processes.RavenMOHYSEProcess' from module 'raven'; the following
exception was raised:
No module named 'xclim.core'
WARNING: autodoc: failed to import process 'processes.RavenHMETSProcess'
from module 'raven'; the following exception was raised:
No module named 'xclim.core'
WARNING: autodoc: failed to import process 'processes.RavenHBVECProcess'
from module 'raven'; the following exception was raised:
No module named 'xclim.core'
WARNING: autodoc: failed to import process
'processes.ObjectiveFunctionProcess' from module 'raven'; the following
exception was raised:
No module named 'xclim.core'
looking for now-outdated files... none found
pickling environment... done
checking consistency...
/home/docs/checkouts/readthedocs.org/user_builds/pavics-raven/checkouts/latest/docs/source/notebooks/Region_selection.ipynb:
WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/pavics-raven/checkouts/latest/docs/source/notebooks/Running_models_with_multiple_timeseries_files.ipynb:
WARNING: document isn't included in any toctree

This PR has been tested on Raven PR https://github.com/Ouranosinc/raven/pull/293, Finch PR https://github.com/bird-house/finch/pull/130, FlyingPigeon https://github.com/bird-house/flyingpigeon/pull/337, https://github.com/bird-house/flyingpigeon/pull/336, Emu https://github.com/bird-house/emu/pull/105