### PR TITLE
travis-ci: build all branches instead of only master

### DIFF
--- a/{{cookiecutter.project_repo_name}}/.travis.yml
+++ b/{{cookiecutter.project_repo_name}}/.travis.yml
@@ -5,9 +5,6 @@ os:
 python:
   - "3.6"
   - "3.7"
-branches:
-  only:
-    - master
 jobs:
   include:
     - os: osx


### PR DESCRIPTION
So all new dev branches are built automatically without having to either
manually add the branch name to .travis.yml or being forced to create a
PR.

This creates redundant build on the same commit when PR is created but
otherwise no other harms.

No redundant build on PR merge since a brand new commit is created for
both merge commit or squash commit scenario.

See discussion
https://github.com/Ouranosinc/raven/pull/292#discussion_r460044455
