### PR TITLE
require pytest 6.0 and nbval 0.9.6

### DIFF
--- a/{{cookiecutter.project_repo_name}}/requirements_dev.txt
+++ b/{{cookiecutter.project_repo_name}}/requirements_dev.txt
@@ -1,11 +1,10 @@
-# https://github.com/computationalmodelling/nbval/issues/139 broken by pytest 6.0.0
-pytest==5.4.3
+pytest>=6.0
 flake8
 pytest-flake8
 ipython
 pytest-notebook
 nbsphinx
-nbval
+nbval>=0.9.6
 nbconvert
 sphinx>=1.7
 bumpversion


### PR DESCRIPTION
The newest major release of pytest (6.0.0) is now compatible with nbval at and above 0.9.6. No more need for specific pinned versions.