### PR TITLE
Test notebooks with --nbval-lax

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 CHANGES
 ********
 
+0.6.0
+=====
+
+Changes:
+
+* `make test-notebooks` now uses `--nbval-lax`. Notebooks will only fail if an error is raised, instead of failing if the cell output is not identical to what is expected.
+
+
 0.5.0 (2020-10-07)
 ==================
 

--- a/{{cookiecutter.project_repo_name}}/Makefile
+++ b/{{cookiecutter.project_repo_name}}/Makefile
@@ -126,7 +126,7 @@ notebook-sanitizer:
 .PHONY: test-notebooks
 test-notebooks: notebook-sanitizer
 	@echo "Running notebook-based tests"
-	@bash -c "env WPS_URL=$(WPS_URL) pytest --nbval --verbose $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output-sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
+	@bash -c "env WPS_URL=$(WPS_URL) pytest --nbval-lax --verbose $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output-sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
## Overview

This PR fixes #105

Changes:

* Use --nbval-lax instead of --nbval in `make test-notebooks`

This is untested. 
Is there a way to run make commands on the generated repo in the test suite ? 
