### PR TITLE
Replace `search` by `parse` in the bumpversion config for `docs/conf.py`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 CHANGES
 ********
 
+0.6.0
+=====
+
+Changes:
+
+* Replace `search` by `parse` in the bumpversion config for `docs/conf.py` to support the `version|release` expression.
+
 0.5.0 (2020-10-07)
 ==================
 

--- a/{{cookiecutter.project_repo_name}}/setup.cfg
+++ b/{{cookiecutter.project_repo_name}}/setup.cfg
@@ -11,7 +11,7 @@ search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
 [bumpversion:file:docs/source/conf.py]
-search = version|release = {current_version}
+parse = version|release = {current_version}
 replace = {new_version}
 
 [bumpversion:file:Dockerfile]


### PR DESCRIPTION
Fix #104

Untested. 