### PR TITLE
Add auto-accept workflow, specify only for CI requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,23 +5,32 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/.github/workflows"
+  - package-ecosystem: github-actions
+    directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     groups:
       actions:
         patterns:
           - "*"
+        update-types:
+          - patch
+          - minor
+          - major
+    cooldown:
+      default-days: 7
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     groups:
-      ci:
-        patterns:
-          - "CI/*"
       python:
         patterns:
-          - "pyproject.toml"
+          - "requirements_ci.*"
+        update-types:
+          - patch
+          - minor
+          - major
+    cooldown:
+      default-days: 7

--- a/.github/workflows/auto-accept-ci-changes.yml
+++ b/.github/workflows/auto-accept-ci-changes.yml
@@ -1,0 +1,72 @@
+name: Dependabot CI Updates
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot-auto-approve:
+    name: Auto-approve and auto-merge safe Dependabot updates
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'dependencies')
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stop workflow if not minor update or patch update
+        id: skip-condition
+        if: >
+          steps.dependabot-metadata.outputs.update-type != 'version-update:semver-minor' &&
+          steps.dependabot-metadata.outputs.update-type != 'version-update:semver-patch'
+        run: |
+          echo "Not a minor or patch update; skipping auto-approval."
+          echo "skip=true" >> $GITHUB_OUTPUT
+
+      - name: Checkout Repository
+        if: steps.skip-condition.outputs.skip != 'true'
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Approve Changes
+        if: steps.skip-condition.outputs.skip != 'true'
+        run: |
+          decision="$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)"
+          if [ "$decision" != "APPROVED" ]; then
+            gh pr review --approve "$PR_URL"
+          else
+            echo "PR already approved: skipping approval."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+
+      - name: Enable auto-merge on Pull Request
+        if: steps.skip-condition.outputs.skip != 'true'
+        run: |
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Overview

This PR creates a workflow that enables automatic accept and automatic merge of `patch` and `minor` updates to CI dependencies (GitHub Workflow Actions and Python libraries). Major changes will still require human intervention

Changes:

* Added `auto-accept-ci-changes.yml`.
* Updated the `dependabot.yml` to run less often and more specifically run only for CI-relevant dependencies.

## Related Issue / Discussion

Security fixes are not calendar-dependent, so the modified frequency of changes will not affect their rollout.

## Additional Information

https://docs.github.com/en/code-security/concepts/supply-chain-security/about-dependabot-version-updates

Motivation for these changes:

> Beginning January 27, 2026, Dependabot will no longer support the https://github.com/dependabot merge command. Please use GitHub's native pull request controls instead. Please see the [changelog announcement](https://github.blog/changelog/2025-10-06-upcoming-changes-to-github-dependabot-pull-request-comment-commands/) for additional details.
